### PR TITLE
Hide 'stable' tags

### DIFF
--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -19,7 +19,7 @@ const tagsDef = [
     },
     {
         name: 'stable',
-        display: false
+        hide: true
     },
     {
         name: 'supported',


### PR DESCRIPTION
`display: false` became `hide: true` since it's displayed by default.