### PR TITLE
Do not build if [skip ci] is used

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -2,7 +2,7 @@
 
 set -exv
 
-if [[ $(git --no-pager  log --oneline -1) == *Bump* ]]; then
+if [[ $(git --no-pager  log --oneline -1) == *\[skip\ ci\]* ]]; then
   exit 1
 fi
 


### PR DESCRIPTION
This lets CI build dependabot updates (such as those introduced by quarkusio/code-quarkus.components updates)