### PR TITLE
Pin 3rd-party actions to SHA1

### DIFF
--- a/.github/workflows/frontend.preview-actions.yml
+++ b/.github/workflows/frontend.preview-actions.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Download PR Artifact
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@b59d8c6a6c5c6c6437954f470d963c0b20ea7415 #v2
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
           workflow_conclusion: success
@@ -30,7 +30,7 @@ jobs:
         id: deploy
         run: npx surge ./ --domain https://code-quarkus-redhat-com-pr-${{  steps.pr.outputs.id }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }}
       - name: Update PR status comment on success
-        uses: actions-cool/maintain-one-comment@v1.2.1
+        uses: actions-cool/maintain-one-comment@ed4d3a59dfe131c1bd46f0d2d57725daad6071d4 #v1.2.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |
@@ -41,7 +41,7 @@ jobs:
           number: ${{ steps.pr.outputs.id }}
       - name: Update PR status comment on failure
         if: ${{ failure() }}
-        uses: actions-cool/maintain-one-comment@v1.2.1
+        uses: actions-cool/maintain-one-comment@ed4d3a59dfe131c1bd46f0d2d57725daad6071d4 #v1.2.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |

--- a/.github/workflows/frontend.preview-teardown-actions.yml
+++ b/.github/workflows/frontend.preview-teardown-actions.yml
@@ -12,7 +12,7 @@ jobs:
         id: deploy
         run: npx surge teardown https://code-quarkus-redhat-com-pr-${{ github.event.number }}-preview.surge.sh --token ${{ secrets.SURGE_TOKEN }}
       - name: Update PR status comment
-        uses: actions-cool/maintain-one-comment@v1.2.1
+        uses: actions-cool/maintain-one-comment@ed4d3a59dfe131c1bd46f0d2d57725daad6071d4 #v1.2.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |

--- a/.github/workflows/frontend.test.actions.yml
+++ b/.github/workflows/frontend.test.actions.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: n1hility/cancel-previous-runs@v2
+      - uses: n1hility/cancel-previous-runs@953c92201f368370112ea2754545cb4468d89f12 #v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Cache Yarn Packages


### PR DESCRIPTION
Hi!

Following the [GH Action Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) guide we should use the commit SHA instead of the `branch` or `tag` for any third-party untrusted action.

This PR was submitted by a script.
