### PR TITLE
Add support:dev-preview to filter list

### DIFF
--- a/src/main/java/OfferingPlatformOverride.java
+++ b/src/main/java/OfferingPlatformOverride.java
@@ -48,8 +48,8 @@ public class OfferingPlatformOverride implements PlatformOverride {
 
     private static final Set<String> TAGS = Set.of(
             "with:starter-code", "status:stable", "status:preview", "status:experimental", "status:deprecated",
-            "support:full-support", "support:supported-in-jvm", "support:dev-support", "support:tech-preview",
-            "support:deprecated");
+            "support:full-support", "support:supported-in-jvm", "support:dev-support", "support:dev-preview",
+            "support:tech-preview", "support:deprecated");
 
     @Override
     public Function<CodeQuarkusExtension, CodeQuarkusExtension> extensionMapper() {

--- a/src/main/resources/web/ibm-app/index.jsx
+++ b/src/main/resources/web/ibm-app/index.jsx
@@ -30,6 +30,12 @@ const tagsDef = [
         background: '#FFDFA6'
     },
     {
+       name: 'support:dev-preview',
+        href: 'https://access.redhat.com/support/offerings/devpreview',
+        color: '#704214',
+        background: '#FFDFA6'
+    },
+    {
         name: 'support:tech-preview',
         description: 'Technology Preview features provide early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process. However, these features are not fully supported under Red Hat Subscription Level Agreements.',
         color: '#0043CE',

--- a/src/main/resources/web/redhat-app/index.jsx
+++ b/src/main/resources/web/redhat-app/index.jsx
@@ -29,6 +29,12 @@ const tagsDef = [
         background: '#FFDFA6'
     },
     {
+        name: 'support:dev-preview',
+        href: 'https://access.redhat.com/support/offerings/devpreview',
+        color: '#704214',
+        background: '#FFDFA6'
+    },
+    {
         name: 'support:tech-preview',
         description: 'Technology Preview features provide early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process. However, these features are not fully supported under Red Hat Subscription Level Agreements.',
         color: '#0043CE',

--- a/src/main/resources/web/redhat-camel-app/index.jsx
+++ b/src/main/resources/web/redhat-camel-app/index.jsx
@@ -30,6 +30,12 @@ const tagsDef = [
         background: '#FFDFA6'
     },
     {
+       name: 'support:dev-preview',
+        href: 'https://access.redhat.com/support/offerings/devpreview',
+        color: '#704214',
+        background: '#FFDFA6'
+    },
+    {
         name: 'support:tech-preview',
         description: 'Technology Preview features provide early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process. However, these features are not fully supported under Red Hat Subscription Level Agreements.',
         color: '#0043CE',


### PR DESCRIPTION
The dev-preview is also valid support value. It should be visible, and be possible to filter by it.

Currently only 2 extension have this status (`"redhat-support" : [ "dev-preview" ]`), and probably it not planned to be exactly big.

For color I don't know which combination to select, so I set the same as `support:dev-support` but it should be probably different. I have no problem to change it but I need to know which color combination to use.