### PR TITLE
feat: Remove load modal for redhat-camel variant

### DIFF
--- a/src/main/resources/web/redhat-camel-app/index.jsx
+++ b/src/main/resources/web/redhat-camel-app/index.jsx
@@ -5,6 +5,11 @@ import {CodeQuarkus, fetchConfig, fetchPlatform} from '../lib';
 import './theme.scss';
 import {CompanyHeader} from './header/company-header';
 
+// Disable QuarkusBlurb popup for redhat-camel variant
+if (typeof localStorage !== 'undefined') {
+    localStorage.setItem('quarkus-blurb-visible-v1', 'true');
+}
+
 const API_URL = window.API_URL;
 const CLIENT_NAME = window.location.hostname;
 const REQUEST_OPTIONS = {headers: {'Client-Name': CLIENT_NAME}};


### PR DESCRIPTION
This remove the display of the following element on the redhat-camel variant of the site :
<img width="780" height="938" alt="Capture d’écran du 2025-11-06 10-40-32" src="https://github.com/user-attachments/assets/2df5608e-3695-4267-8d19-7c10bbd0aa25" />

@ia3andy If there is a better way to do it or a reason for not doing such thing don't hesitate to tell me :pray: 