### PR TITLE
feat: Only keep maven as buildtool for redhat-camel variant

### DIFF
--- a/src/main/resources/web/redhat-camel-app/theme.scss
+++ b/src/main/resources/web/redhat-camel-app/theme.scss
@@ -163,3 +163,8 @@
   --blurbInfoIconColor: var(--primary);
 }
 
+// Hide Gradle build tool options - only show Maven
+#buildtool option[value="GRADLE"],
+#buildtool option[value="GRADLE_KOTLIN_DSL"] {
+  display: none;
+}


### PR DESCRIPTION
<img width="1524" height="836" alt="Capture d’écran du 2025-11-12 11-55-59" src="https://github.com/user-attachments/assets/712541b3-c82d-4e70-8bc7-93de0d9d53ea" />
