### PR TITLE
Add Red Hat Maven repository to generated projects

### DIFF
--- a/src/main/java/OfferingPlatformOverride.java
+++ b/src/main/java/OfferingPlatformOverride.java
@@ -73,6 +73,7 @@ public class OfferingPlatformOverride implements PlatformOverride {
     private List<String> getRepositories() {
         return switch (config.id()) {
             case "ibm" -> IBMConstants.IBM_POM_REPOSITORIES;
+            case "redhat", "redhat-camel" -> RedHatConstants.REDHAT_POM_REPOSITORIES;
             default -> null;
         };
     }


### PR DESCRIPTION
## Summary
- Add the Red Hat Maven repository (`maven.repository.redhat.com/ga/`) to generated project pom.xml files for both `redhat` and `redhat-camel` offerings
- Previously only the `ibm` offering had its repository override configured in `getRepositories()`
- The `RedHatConstants.REDHAT_POM_REPOSITORIES` was already defined but never wired in