### PR TITLE
feat: Quarkus REDHAT/IBM - Add field name for support tags

### DIFF
--- a/src/main/resources/web/ibm-app/index.jsx
+++ b/src/main/resources/web/ibm-app/index.jsx
@@ -14,38 +14,44 @@ const tagsDef = [
         name: 'support:full-support',
         description: 'Full-support for development and production phases.',
         color: '#0E6027',
-        background: '#A7F0BA'
+        background: '#A7F0BA',
+        showFullName: true
 
     },
     {
         name: 'support:supported-in-jvm',
         description: 'Support in JVM, means that this extension is tested and verified for usage in a Java Virtual Machine.',
         color: '#0E6027',
-        background: '#D4F4E1'
+        background: '#D4F4E1',
+        showFullName: true
     },
     {
         name: 'support:dev-support',
         description: 'Support and advice for development phase.',
         color: '#704214',
-        background: '#FFDFA6'
+        background: '#FFDFA6',
+        showFullName: true
     },
     {
-       name: 'support:dev-preview',
+        name: 'support:dev-preview',
         description: 'Developer Preview features are provided to expose features from upstream communities allowing early adopters and integrators to explore and interact with new capabilities in advance of their possible inclusion.',
         color: '#6929C4',
-        background: '#E8DAFF'
+        background: '#E8DAFF',
+        showFullName: true
     },
     {
         name: 'support:tech-preview',
         description: 'Technology Preview features provide early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process. However, these features are not fully supported.',
         color: '#0043CE',
-        background: '#D0E2FF'
+        background: '#D0E2FF',
+        showFullName: true
     },
     {
         name: 'support:deprecated',
         description: 'This feature is likely to be replaced or removed in a future version of IBM Enterprise Build of Quarkus.',
         background: '#6a737d',
         color: '#ffffff',
+        showFullName: true
     },
     {
         name: 'status:preview',

--- a/src/main/resources/web/redhat-app/index.jsx
+++ b/src/main/resources/web/redhat-app/index.jsx
@@ -14,37 +14,43 @@ const tagsDef = [
         name: 'support:full-support',
         href: 'https://access.redhat.com/support/offerings/production/soc/',
         color: '#0E6027',
-        background: '#A7F0BA'
+        background: '#A7F0BA',
+        showFullName: true
     },
     {
         name: 'support:supported-in-jvm',
         description: 'Support in JVM, means that this extension is tested and verified for usage in a Java Virtual Machine.',
         color: '#0E6027',
-        background: '#D4F4E1'
+        background: '#D4F4E1',
+        showFullName: true
     },
     {
         name: 'support:dev-support',
         href: 'https://access.redhat.com/support/offerings/developer/soc/',
         color: '#704214',
-        background: '#FFDFA6'
+        background: '#FFDFA6',
+        showFullName: true
     },
     {
         name: 'support:dev-preview',
         href: 'https://access.redhat.com/support/offerings/devpreview',
         color: '#6929C4',
-        background: '#E8DAFF'
+        background: '#E8DAFF',
+        showFullName: true
     },
     {
         name: 'support:tech-preview',
         description: 'Technology Preview features provide early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process. However, these features are not fully supported under Red Hat Subscription Level Agreements.',
         color: '#0043CE',
-        background: '#D0E2FF'
+        background: '#D0E2FF',
+        showFullName: true
     },
     {
         name: 'support:deprecated',
         description: 'This feature is likely to be replaced or removed in a future version of Red Hat build of Quarkus. See release notes on docs.redhat.com for more information.',
         background: '#6a737d',
-        color: '#ffffff'
+        color: '#ffffff',
+        showFullName: true
     },
     {
         name: 'status:preview',

--- a/src/main/resources/web/redhat-app/theme.scss
+++ b/src/main/resources/web/redhat-app/theme.scss
@@ -165,7 +165,7 @@
 
   // Tags namespace
   --tagNameColor: var(--primary);
-  --tagNameBackground: var(--background2);
+  --tagNameBackground: var(--background);
   --tagNameBorder: none;
 }
 


### PR DESCRIPTION
Add field name for support tags to ensure the customer understand what is the support information.

<img width="320" height="180" alt="Capture d’écran du 2026-05-19 09-17-30" src="https://github.com/user-attachments/assets/7b575610-f50e-4585-a4a4-2621c44f0c18" />
<img width="320" height="180" alt="Capture d’écran du 2026-05-19 09-23-36" src="https://github.com/user-attachments/assets/eb4c7486-e575-4b33-ace1-4d9f80188689" />
